### PR TITLE
Do not quote ssid and password

### DIFF
--- a/wifi2qr
+++ b/wifi2qr
@@ -81,12 +81,12 @@ do
         echo "ERROR: connection '$conn' is $val, not WiFi" 2>&1;
         exit 1;
     elif [[ "$parm" == "802-11-wireless.ssid" ]]; then
-        ssid="S:\"$val\";"
+        ssid="S:$val;"
     elif [[ "$parm" == "802-11-wireless.hidden" && "$val" == "yes" ]]; then
         hidden="H:true;"
     elif [[ "$parm" == "802-11-wireless-security.psk" ]]; then
         pass="T:WPA;"
-        [[ -n "$val" ]] && pass+="P:\"$val\";"
+        [[ -n "$val" ]] && pass+="P:${val//://:};"
     elif [[ "$parm" == "802-1x.eap" && -n "$val" ]]; then
         eap+="E:$val;"
     elif [[ "$parm" == "802-1x.anonymous-identity" && -n "$val" ]]; then


### PR DESCRIPTION
The script was not working for me on iOS. This reference

https://feeding.cloud.geek.nz/posts/encoding-wifi-access-point-passwords-qr-code/

suggests that the problem are the quotes on SSID and password, which iOS does not accept.

Modify the script so as to remove the quotes. Quote colons in the password as suggested by the reference.